### PR TITLE
Use Elixir 1.0.5

### DIFF
--- a/1.0/Dockerfile
+++ b/1.0/Dockerfile
@@ -1,9 +1,11 @@
 FROM azukiapp/erlang
 MAINTAINER Azuki <support@azukiapp.com>
 
+ENV ELIXIR_VERSION 1.0.5-2
+
 # Install local Elixir hex and rebar
 RUN  apt-get -qq update \
-  && apt-get install -qqy erlang-inets elixir \
+  && apt-get install -y elixir=${ELIXIR_VERSION} \
   && /usr/local/bin/mix local.hex --force \
   && /usr/local/bin/mix local.rebar --force \
   && apt-get autoremove --purge \

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Versions (tags)
 ---
 
 <versions>
-- [`latest`, `1`, `1.0`, `1.0.3`](https://github.com/azukiapp/docker-elixir/blob/master/1.0/Dockerfile)
+- [`latest`, `1`, `1.0`, `1.0.5`](https://github.com/azukiapp/docker-elixir/blob/master/1.0/Dockerfile)
 </versions>
 
 Image content:
@@ -16,9 +16,6 @@ Image content:
 - Ubuntu 14.04
 - Git
 - VIM
-
-Database:
-
 - Erlang
 - Elixir
 


### PR DESCRIPTION
This pull request does the following:
- Upgrades to the latest Elixir version, 1.0.5
- Updates the README (Elixir is not a database)

It is dependent on [#2](https://github.com/azukiapp/docker-erlang/pull/2) in [`docker-erlang`](https://github.com/azukiapp/docker-erlang).
